### PR TITLE
Prevent compiler warnings due to always-match clauses

### DIFF
--- a/lib/async_with/clauses.ex
+++ b/lib/async_with/clauses.ex
@@ -27,8 +27,7 @@ defmodule AsyncWith.Clauses do
     * Clauses with match operator - `a = 1`
     * Bare expressions - `my_function(a)` - However, bare expressions are converted to
       clauses with match operator `_ = my_function(a)` to ensure both left and right sides
-      are always present. This homogenization processs simplifies the building of the
-      `AsyncWith.DependencyGraph` and the generation of the final Abstract Syntax Tree.
+      are always present.
 
   Each clause is mapped into the following Elixir struct:
 

--- a/lib/async_with/clauses.ex
+++ b/lib/async_with/clauses.ex
@@ -31,7 +31,8 @@ defmodule AsyncWith.Clauses do
 
   Each clause is mapped into the following Elixir struct:
 
-    * `function` - Either match `:=` or send `:<-` operators.
+    * `function` - A function that executes the clause and collects the values of its defined
+      variables.
     * `defined_vars` - The list of variables binded/defined in the clause.
     * `used_vars` - The list of variables used in the clause (including pin matching).
     * `guard_vars` - The list of variables used in the guard clause.
@@ -40,7 +41,7 @@ defmodule AsyncWith.Clauses do
   be mapped to an struct with the following attributes:
 
     * `function` would be something similar to
-      `with {:ok, {^a, b}} when is_binary(b) <- echo(c, d), do: {:ok, [b: b]}`.
+      `fn -> with {:ok, {^a, b}} when is_binary(b) <- echo(c, d), do: {:ok, [b: b]} end`.
     * `defined_vars` would be `[:b]`.
     * `used_vars` would be `[:a, :c, :d]`.
     * `guard_vars` would be `[:b]`.
@@ -51,11 +52,10 @@ defmodule AsyncWith.Clauses do
 
     * Variables that are used but not defined in previous clauses are considered external.
       External variables are removed from the list of `used_vars`, as they shouldn't be
-      considered when building the dependency graph.
-    * Variables that are rebinded in next clauses are renamed to avoid collisions when building
-      the dependency graph.
-    * Ignored variables are renamed to avoid compiler warnings. See
-      `AsyncWith.Macro.DependencyGraph.to_ast/2` for more information.
+      considered dependencies.
+    * Variables that are rebinded in next clauses are renamed to avoid collisions when collecting
+      the results.
+    * Ignored variables are renamed to avoid compiler warnings.
 
   Variables are renamed using the following pattern:
 

--- a/lib/async_with/macro.ex
+++ b/lib/async_with/macro.ex
@@ -69,6 +69,28 @@ defmodule AsyncWith.Macro do
   defp do_get_guard_vars(ast) when is_tuple(ast), do: ast |> Tuple.to_list() |> do_get_guard_vars()
   defp do_get_guard_vars(_ast), do: []
 
+  @doc """
+  Returns true if the `ast` represents a variable.
+
+  ## Examples
+
+      iex> ast = quote(do: a)
+      iex> AsyncWith.Macro.var?(ast)
+      true
+
+      iex> ast = quote(do: {:ok, 1})
+      iex> AsyncWith.Macro.var?(ast)
+      false
+
+  """
+  @spec var?(Macro.t) :: boolean
+  def var?(ast) do
+    case ast do
+      {var, _meta, args} when is_atom(var) and not is_list(args) -> true
+      _ -> false
+    end
+  end
+
   @doc ~S"""
   Returns an AST node where each variable is replaced by the the result of invoking
   `funtion` on that variable.


### PR DESCRIPTION
The template used to generate the functions for arrow operators `a <- 1` in `Clauses.from_ast/1` follows this structure:

```elixir
with <left> <- <right> do
  {:ok, <values>}
else
  error -> {:error, error}
end
```

This pattern works with most of the clauses, but with _always-match_ clauses it made the compiler to emit `warning: "else" clauses will never match because all patterns in "with" will always match`. Here is an example:

```elixir
with a <- 1 do
  {:ok, [a: a]}
else
  error -> {:error, error}
end
```

To prevent those warnings, _always-match_ clauses are now converted to assignments `a = 1` (which use a different template). 

In addition, this PR also configures `async with` to emit warnings imitating `with` behavior:

```elixir
async with a <- 1 do
  a
else
  error -> error
end

warning: "else" clauses will never match because all patterns in "async with" will always match
  test.ex:6: FOO.foo/0
```

Closes #2 